### PR TITLE
chokidar events improvements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,21 +1,55 @@
-export default (callback) => (input) => {
+export default (files, opts = {}) => (callback) => () => {
+
+  if (!files || (Array.isArray(files) && !files.length)) {
+    throw new Error('Need files to watch');
+  }
+  if (!callback || typeof callback !== 'function') {
+    throw new Error('Need a callback function');
+  }
+
   return function watch(log) {
     const chokidar = require('chokidar');
 
-    return new Promise((resolve, reject) => {
-      const init = () => {
-        chokidar
-          .watch(input, { persistent: true })
-          .on('change', callback)
-          .on('error', reject)
-          .on('ready', () => {
-            log('press ctrl-c to exit');
-          });
-      };
+    const events = opts.events || [ 'add', 'change' ];
 
-      callback(input)
-        .then(init)
-        .catch(init);
+    return new Promise((resolve, reject) => {
+
+      log('Globbing files...');
+
+      const initialFileList = [];
+      const initialListener = (file) => initialFileList.push(file);
+
+      const watcher = chokidar.watch(files, { persistent: true, ...opts });
+
+      watcher.once('error', reject);
+
+      watcher.on('add', initialListener);
+      watcher.once('ready', () => {
+        watcher.removeListener('add', initialListener);
+
+        log('initial scan complete, running task...');
+
+        const callbackPromise = callback(initialFileList);
+
+        if (!callbackPromise || !callbackPromise.then) {
+          return reject(new Error('Callback did not return a promise.'));
+        }
+
+        callbackPromise.then((data) => {
+          log('watching for changes, press ctrl-c to exit');
+          events.forEach((event) => watcher.on(event, (file) => callback([ file ])));
+          resolve(data);
+
+          return data;
+        }).catch((err) => {
+          if (opts.bail) {
+            reject(err);
+          } else {
+            log('reject', err);
+            resolve();
+          }
+        });
+      });
     });
   };
 };

--- a/readme.md
+++ b/readme.md
@@ -34,9 +34,8 @@ cosnt start = Start(reporter());
 export const dev = () => start(
   files('build/'),
   clean(),
-  files('lib/**/*.js'),
-  watch(file => start(
-    files(file),
+  watch('lib/**/*.js')((changedFiles) => start(
+    files(changedFiles),
     read(),
     babel(),
     write('build/')
@@ -44,15 +43,14 @@ export const dev = () => start(
 );
 
 export const tdd = () => start(
-  files([ 'lib/**/*.js', 'test/**/*.js']),
-  watch(() => start(
-    files('test/**/*.js'),
+  watch([ 'lib/**/*.js', 'test/**/*.js'], {...chokidarOpts})((changedFiles) => start(
+    files(changedFiles),
     mocha()
   ))
 );
 ```
 
-This task relies on array of files, see [documentation](https://github.com/start-runner/start#readme) for details.
+See [documentation](https://github.com/start-runner/start#readme) for details.
 
 :point_right: Note that this task may not work properly with tasks like [start-webpack](https://github.com/start-runner/webpack) and [start-karma](https://github.com/start-runner/karma) which have their own file watching functionality.
 
@@ -60,4 +58,4 @@ This task relies on array of files, see [documentation](https://github.com/start
 
 `watch(callback)`
 
-* `callback(file)` – callback function which will be called on matched file changes
+* `callback(files)` – callback function which will be called on matched file changes


### PR DESCRIPTION
[breaking change]

old syntax:
```js
start(
  files(...)
  watch(callback)
)
```
new syntax:
```js
start(
  watch([...files], {...opts})(callback)
)
```
`callback` must return a promise.

Supports passing options, events directly to chokidar.

Adds the "add" event by default.

Makes sure changedFiles passed to callback is always an array
